### PR TITLE
fix: remove stray puts and add missing requires in graphql_query

### DIFF
--- a/lib/puppet/functions/graphql/graphql_query.rb
+++ b/lib/puppet/functions/graphql/graphql_query.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require 'json'
+require 'net/http'
+require 'uri'
 
 # Query a GraphQL API via HTTP.
 Puppet::Functions.create_function(:"graphql::graphql_query") do
@@ -31,7 +33,6 @@ Puppet::Functions.create_function(:"graphql::graphql_query") do
       end
       JSON.parse(response.body)
     rescue => error
-      puts error
       Puppet.err "graphql::graphql_query: #{error}!"
       call_function('create_resources', 'notify', { "graphql::graphql_query: #{error}!" => {} })
       nil


### PR DESCRIPTION
The error handler in `graphql_query` contained a `puts error` call that writes to stdout, which is meaningless on a puppetserver since the error is already logged via `Puppet.err` and reported through a `notify` resource. Also adds explicit `require` statements for `net/http` and `uri` which the function uses but only loaded implicitly through Puppet's runtime.